### PR TITLE
Add pagination for wallet transaction history

### DIFF
--- a/__tests__/pages/wallet/util/submitTransactionForm.tsx
+++ b/__tests__/pages/wallet/util/submitTransactionForm.tsx
@@ -1,0 +1,53 @@
+import { screen, within } from "@testing-library/react"
+import { UserEvent } from "@testing-library/user-event/setup/setup"
+
+export function getForm(): HTMLElement {
+  return screen.getByLabelText("add-transaction-form")
+}
+
+export function getNameInput(): HTMLInputElement {
+  const form: HTMLElement = getForm()
+  return within(form).getByRole("textbox", { name: "Name" })
+}
+
+export function getAmountInput(): HTMLInputElement {
+  const form: HTMLElement = getForm()
+  return within(form).getByRole("spinbutton", { name: "Amount" })
+}
+
+export function getIncomeInput(): HTMLElement {
+  return within(getForm()).getByRole("radio", { name: "Income" })
+}
+
+export function getExpenseInput(): HTMLElement {
+  return within(getForm()).getByRole("radio", { name: "Expense" })
+}
+
+export function getSubmitButton(): HTMLButtonElement {
+  const form: HTMLElement = getForm()
+  return within(form).getByRole("button", { name: "Submit" })
+}
+
+export async function submitIncomeTransaction(user: UserEvent, name: string, amount: string) {
+  const nameInput: HTMLInputElement = getNameInput()
+  const amountInput: HTMLInputElement = getAmountInput()
+  await pasteText(user, nameInput, name)
+  await pasteText(user, amountInput, amount)
+  await user.click(getIncomeInput())
+  await user.click(getSubmitButton())
+}
+
+export async function submitExpenseTransaction(user: UserEvent, name: string, amount: string) {
+  const nameInput: HTMLInputElement = getNameInput()
+  const amountInput: HTMLInputElement = getAmountInput()
+  await pasteText(user, nameInput, name)
+  await pasteText(user, amountInput, amount)
+  await user.click(getExpenseInput())
+  await user.click(getSubmitButton())
+}
+
+async function pasteText(user: UserEvent, input: HTMLInputElement, text: string) {
+  await user.clear(input)
+  await user.click(input)
+  await user.paste(text)
+}

--- a/__tests__/pages/wallet/util/walletElementSelectors.tsx
+++ b/__tests__/pages/wallet/util/walletElementSelectors.tsx
@@ -1,0 +1,5 @@
+import { screen } from "@testing-library/react"
+
+export function getTransactionHistory(): HTMLElement {
+  return screen.getByLabelText("wallet-transaction-history")
+}

--- a/__tests__/pages/wallet/wallet.pagination.test.tsx
+++ b/__tests__/pages/wallet/wallet.pagination.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest"
+import { render, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { UserEvent } from "@testing-library/user-event/setup/setup"
+import { getTransactionHistory } from "./util/walletElementSelectors"
+import { submitExpenseTransaction } from "./util/submitTransactionForm"
+import Wallet from "../../../pages/wallet"
+
+describe("pagination", () => {
+  const user: UserEvent = userEvent.setup()
+  const transactionsPerPage: number = 10
+  const VALID_NAME: string = "test name"
+  const VALID_AMOUNT: string = "3.00"
+
+  function getAllTransactionOnPage(): HTMLElement[] {
+    const transactionHistory: HTMLElement = getTransactionHistory()
+    return within(transactionHistory)
+      .getAllByRole("generic", { name: "transaction" })
+  }
+
+  function getPreviousPaginationButton(): HTMLButtonElement {
+    const transactionHistory: HTMLElement = getTransactionHistory()
+    return within(transactionHistory).getByRole("button", { name: "previous-transaction-history" })
+  }
+
+  function getNextPaginationButton(): HTMLButtonElement {
+    const transactionHistory: HTMLElement = getTransactionHistory()
+    return within(transactionHistory).getByRole("button", { name: "next-transaction-history" })
+  }
+
+  function getCurrentPageNumber(): HTMLElement {
+    const transactionHistory: HTMLElement = getTransactionHistory()
+    return within(transactionHistory).getByRole("button",
+      { name: "current-transaction-history-page" })
+  }
+
+  describe("current page number", () => {
+    test("should start page number as 1", async () => {
+      render(<Wallet />)
+      expect(getCurrentPageNumber().textContent).toBe("1")
+    })
+
+    test("should show page number as 2 when next page is viewed", async () => {
+      render(<Wallet />)
+      expect(getCurrentPageNumber().textContent).toBe("1")
+      for (let i = 0; i < transactionsPerPage + 1; i++) {
+        await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
+      }
+      await user.click(getNextPaginationButton())
+      expect(getCurrentPageNumber().textContent).toBe("2")
+    })
+  })
+
+  describe("pagination buttons", () => {
+    test("should show pagination buttons", async () => {
+      render(<Wallet />)
+      expect(getPreviousPaginationButton()).toBeInTheDocument()
+      expect(getNextPaginationButton()).toBeInTheDocument()
+    })
+
+    test("should have previous pagination button disabled for first page", async () => {
+      render(<Wallet />)
+      expect(getPreviousPaginationButton()).toBeDisabled()
+    })
+
+    test("should have next pagination button disabled for zero transactions", async () => {
+      render(<Wallet />)
+      expect(getNextPaginationButton()).toBeDisabled()
+    })
+
+    test("should have next pagination button disabled for last page", async () => {
+      render(<Wallet />)
+      for (let i = 0; i < transactionsPerPage + 1; i++) {
+        await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
+      }
+      const nextPage: HTMLButtonElement = getNextPaginationButton()
+      expect(nextPage).not.toBeDisabled()
+      await user.click(nextPage)
+      expect(nextPage).toBeDisabled()
+    })
+
+    test("should have next pagination button disabled for first 10 transactions", async () => {
+      render(<Wallet />)
+      const nextPage: HTMLButtonElement = getNextPaginationButton()
+      expect(nextPage).toBeDisabled()
+      for (let i = 0; i < transactionsPerPage; i++) {
+        await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
+      }
+      expect(nextPage).toBeDisabled()
+    })
+  })
+
+  test("should show 10 transactions per page", async () => {
+    render(<Wallet />)
+    for (let i = 0; i < transactionsPerPage + 1; i++) {
+      await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
+    }
+    expect(getAllTransactionOnPage().length).toEqual(10)
+    await user.click(getNextPaginationButton())
+    expect(getAllTransactionOnPage().length).toEqual(1)
+  })
+})

--- a/__tests__/pages/wallet/wallet.test.tsx
+++ b/__tests__/pages/wallet/wallet.test.tsx
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "vitest"
 import { render, screen } from "@testing-library/react"
-import Wallet from "../../pages/wallet"
+import Wallet from "../../../pages/wallet"
 
 function getMonth(date: Date) {
   const monthNames = ["January", "February", "March", "April", "May", "June",

--- a/__tests__/pages/wallet/wallet.transactions.test.tsx
+++ b/__tests__/pages/wallet/wallet.transactions.test.tsx
@@ -1,63 +1,20 @@
 import { describe, expect, test } from "vitest"
 import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup"
-import Wallet from "../../../pages/wallet"
+import { UserEvent } from "@testing-library/user-event/setup/setup"
 import format from "date-fns/format"
-
-const VALID_NAME: string = "test name"
-const VALID_AMOUNT: string = "3.00"
-const user: UserEvent = userEvent.setup()
+import {
+  getAmountInput, getExpenseInput, getIncomeInput,
+  getNameInput,
+  submitExpenseTransaction,
+  submitIncomeTransaction
+} from "./util/submitTransactionForm"
+import Wallet from "../../../pages/wallet"
 
 describe("transactions", () => {
-  function getForm(): HTMLElement {
-    return screen.getByLabelText("add-transaction-form")
-  }
-
-  function getNameInput(): HTMLInputElement {
-    const form: HTMLElement = getForm()
-    return within(form).getByRole("textbox", { name: "Name" })
-  }
-
-  function getAmountInput(): HTMLInputElement {
-    const form: HTMLElement = getForm()
-    return within(form).getByRole("spinbutton", { name: "Amount" })
-  }
-
-  function getIncomeInput(): HTMLElement {
-    return within(getForm()).getByRole("radio", { name: "Income" })
-  }
-
-  function getExpenseInput(): HTMLElement {
-    return within(getForm()).getByRole("radio", { name: "Expense" })
-  }
-
-  function getSubmitButton(): HTMLButtonElement {
-    const form: HTMLElement = getForm()
-    return within(form).getByRole("button", { name: "Submit" })
-  }
-
-  async function submitIncomeTransaction(name: string, amount: string) {
-    const nameInput: HTMLInputElement = getNameInput()
-    const amountInput: HTMLInputElement = getAmountInput()
-    await user.clear(nameInput)
-    await user.type(nameInput, name)
-    await user.clear(amountInput)
-    await user.type(amountInput, amount)
-    await user.click(getIncomeInput())
-    await user.click(getSubmitButton())
-  }
-
-  async function submitExpenseTransaction(name: string, amount: string) {
-    const nameInput: HTMLInputElement = getNameInput()
-    const amountInput: HTMLInputElement = getAmountInput()
-    await user.clear(nameInput)
-    await user.type(nameInput, name)
-    await user.clear(amountInput)
-    await user.type(amountInput, amount)
-    await user.click(getExpenseInput())
-    await user.click(getSubmitButton())
-  }
+  const user: UserEvent = userEvent.setup()
+  const VALID_NAME: string = "test name"
+  const VALID_AMOUNT: string = "3.00"
 
   function assertEmptyInput(input: HTMLInputElement): void {
     expect(input).toBeInTheDocument()
@@ -123,7 +80,7 @@ describe("transactions", () => {
       const amount: string = "-0.01"
       const amountInput: HTMLInputElement = getAmountInput()
       assertEmptyInput(amountInput)
-      await submitExpenseTransaction(VALID_NAME, amount)
+      await submitExpenseTransaction(user, VALID_NAME, amount)
       expect(amountInput).toBeInvalid()
     })
 
@@ -132,7 +89,7 @@ describe("transactions", () => {
       const amount: string = "23.231"
       const amountInput: HTMLInputElement = getAmountInput()
       assertEmptyInput(amountInput)
-      await submitExpenseTransaction(VALID_NAME, amount)
+      await submitExpenseTransaction(user, VALID_NAME, amount)
       expect(amountInput).toBeInvalid()
     })
 
@@ -141,7 +98,7 @@ describe("transactions", () => {
       const amount: string = "2.01"
       const amountInput: HTMLInputElement = getAmountInput()
       assertEmptyInput(amountInput)
-      await submitExpenseTransaction(VALID_NAME, amount)
+      await submitExpenseTransaction(user, VALID_NAME, amount)
       expect(amountInput).not.toBeInvalid()
     })
 
@@ -150,7 +107,7 @@ describe("transactions", () => {
       const amount: string = "0.00"
       const amountInput: HTMLInputElement = getAmountInput()
       assertEmptyInput(amountInput)
-      await submitExpenseTransaction(VALID_NAME, amount)
+      await submitExpenseTransaction(user, VALID_NAME, amount)
       expect(amountInput).toBeInvalid()
     })
 
@@ -159,7 +116,7 @@ describe("transactions", () => {
       const amount: string = "0.01"
       const amountInput: HTMLInputElement = getAmountInput()
       assertEmptyInput(amountInput)
-      await submitExpenseTransaction(VALID_NAME, amount)
+      await submitExpenseTransaction(user, VALID_NAME, amount)
       expect(amountInput).not.toBeInvalid()
     })
 
@@ -168,10 +125,10 @@ describe("transactions", () => {
       const amount: string = "9999999999"
       const amountInput: HTMLInputElement = getAmountInput()
       assertEmptyInput(amountInput)
-      await submitExpenseTransaction(VALID_NAME, amount)
+      await submitExpenseTransaction(user, VALID_NAME, amount)
       expect(amountInput).not.toBeInvalid()
 
-      await submitExpenseTransaction(VALID_NAME, amount + ".01")
+      await submitExpenseTransaction(user, VALID_NAME, amount + ".01")
       expect(amountInput).toBeInvalid()
     })
   })
@@ -217,7 +174,7 @@ describe("transactions", () => {
       render(<Wallet />)
       const transactionHistory: HTMLElement = getTransactionHistory()
       assertEmptyTransactionHistory(transactionHistory)
-      await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+      await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
       assertTransactionHistoryContains(transactionHistory, VALID_NAME, VALID_AMOUNT)
     })
 
@@ -225,7 +182,7 @@ describe("transactions", () => {
       render(<Wallet />)
       const transactionHistory: HTMLElement = getTransactionHistory()
       assertEmptyTransactionHistory(transactionHistory)
-      await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+      await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
       const transactionDeleteButton: HTMLElement = getFirstTransactionDeleteButton()
       expect(transactionDeleteButton).toBeInTheDocument()
     })
@@ -234,104 +191,12 @@ describe("transactions", () => {
       render(<Wallet />)
       const transactionHistory: HTMLElement = getTransactionHistory()
       assertEmptyTransactionHistory(transactionHistory)
-      await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+      await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
       assertTransactionHistoryContains(transactionHistory, VALID_NAME, VALID_AMOUNT)
       const transactionDeleteButton: HTMLElement = getFirstTransactionDeleteButton()
       await user.click(transactionDeleteButton)
       expect(transactionHistory.textContent).not.toContain(VALID_NAME)
       expect(transactionHistory.textContent).not.toContain("$" + VALID_AMOUNT)
-    })
-
-    describe("pagination", () => {
-      const transactionsPerPage: number = 10
-
-      function getAllTransactionOnPage(): HTMLElement[] {
-        const transactionHistory: HTMLElement = getTransactionHistory()
-        return within(transactionHistory)
-          .getAllByRole("generic", { name: "transaction" })
-      }
-
-      function getPreviousPaginationButton(): HTMLButtonElement {
-        const transactionHistory: HTMLElement = getTransactionHistory()
-        return within(transactionHistory).getByRole("button", { name: "previous-transaction-history" })
-      }
-
-      function getNextPaginationButton(): HTMLButtonElement {
-        const transactionHistory: HTMLElement = getTransactionHistory()
-        return within(transactionHistory).getByRole("button", { name: "next-transaction-history" })
-      }
-
-      function getCurrentPageNumber(): HTMLElement {
-        const transactionHistory: HTMLElement = getTransactionHistory()
-        return within(transactionHistory).getByRole("button",
-          { name: "current-transaction-history-page" })
-      }
-
-      describe("current page number", () => {
-        test("should start page number as 1", async () => {
-          render(<Wallet />)
-          expect(getCurrentPageNumber().textContent).toBe("1")
-        })
-
-        test("should show page number as 2 when next page is viewed", async () => {
-          render(<Wallet />)
-          expect(getCurrentPageNumber().textContent).toBe("1")
-          for (let i = 0; i < transactionsPerPage + 1; i++) {
-            await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
-          }
-          await user.click(getNextPaginationButton())
-          expect(getCurrentPageNumber().textContent).toBe("2")
-        })
-      })
-
-      describe("pagination buttons", () => {
-        test("should show pagination buttons", async () => {
-          render(<Wallet />)
-          expect(getPreviousPaginationButton()).toBeInTheDocument()
-          expect(getNextPaginationButton()).toBeInTheDocument()
-        })
-
-        test("should have previous pagination button disabled for first page", async () => {
-          render(<Wallet />)
-          expect(getPreviousPaginationButton()).toBeDisabled()
-        })
-
-        test("should have next pagination button disabled for zero transactions", async () => {
-          render(<Wallet />)
-          expect(getNextPaginationButton()).toBeDisabled()
-        })
-
-        test("should have next pagination button disabled for last page", async () => {
-          render(<Wallet />)
-          for (let i = 0; i < transactionsPerPage + 1; i++) {
-            await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
-          }
-          const nextPage: HTMLButtonElement = getNextPaginationButton()
-          expect(nextPage).not.toBeDisabled()
-          await user.click(nextPage)
-          expect(nextPage).toBeDisabled()
-        })
-
-        test("should have next pagination button disabled for first 10 transactions", async () => {
-          render(<Wallet />)
-          const nextPage: HTMLButtonElement = getNextPaginationButton()
-          expect(nextPage).toBeDisabled()
-          for (let i = 0; i < transactionsPerPage; i++) {
-            await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
-          }
-          expect(nextPage).toBeDisabled()
-        })
-      })
-
-      test("should show 10 transactions per page", async () => {
-        render(<Wallet />)
-        for (let i = 0; i < transactionsPerPage + 1; i++) {
-          await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
-        }
-        expect(getAllTransactionOnPage().length).toEqual(10)
-        await user.click(getNextPaginationButton())
-        expect(getAllTransactionOnPage().length).toEqual(1)
-      })
     })
 
     describe("transaction count", () => {
@@ -356,22 +221,22 @@ describe("transactions", () => {
         test("should show one transaction count", async () => {
           render(<Wallet />)
           assertZeroTransactionCount()
-          await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+          await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
           assertTransactionCount(1)
         })
 
         test("should show multiple transaction count", async () => {
           render(<Wallet />)
           assertZeroTransactionCount()
-          await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
-          await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+          await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
+          await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
           assertTransactionCount(2)
         })
 
         test("should reduce transaction count when transaction is deleted", async () => {
           render(<Wallet />)
           assertZeroTransactionCount()
-          await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+          await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
           assertTransactionCount(1)
           await user.click(getFirstTransactionDeleteButton())
           assertZeroTransactionCount()
@@ -388,7 +253,7 @@ describe("transactions", () => {
         render(<Wallet />)
         const amount: string = "3.20"
         assertEmptyInput(getAmountInput())
-        await submitExpenseTransaction(VALID_NAME, amount)
+        await submitExpenseTransaction(user, VALID_NAME, amount)
         expect(getExpenseTotalElement()).toHaveTextContent("$3.20")
       })
 
@@ -397,8 +262,8 @@ describe("transactions", () => {
         const amount: string = "3.20"
         const amountInput: HTMLInputElement = getAmountInput()
         assertEmptyInput(amountInput)
-        await submitExpenseTransaction(VALID_NAME, amount)
-        await submitExpenseTransaction(VALID_NAME, amount)
+        await submitExpenseTransaction(user, VALID_NAME, amount)
+        await submitExpenseTransaction(user, VALID_NAME, amount)
         expect(getExpenseTotalElement()).toHaveTextContent("$6.40")
       })
 
@@ -406,7 +271,7 @@ describe("transactions", () => {
         render(<Wallet />)
         const amount: string = "3.20"
         assertEmptyInput(getAmountInput())
-        await submitExpenseTransaction(VALID_NAME, amount)
+        await submitExpenseTransaction(user, VALID_NAME, amount)
         expect(getExpenseTotalElement()).toHaveTextContent("$3.20")
         await user.click(getFirstTransactionDeleteButton())
         expect(getExpenseTotalElement()).toHaveTextContent("$0.00")
@@ -423,7 +288,7 @@ describe("transactions", () => {
         const amount: string = "3.20"
         const amountInput: HTMLInputElement = getAmountInput()
         assertEmptyInput(amountInput)
-        await submitIncomeTransaction(VALID_NAME, amount)
+        await submitIncomeTransaction(user, VALID_NAME, amount)
         expect(getIncomeTotalElement()).toHaveTextContent("$3.20")
       })
 
@@ -432,8 +297,8 @@ describe("transactions", () => {
         const amount: string = "3.20"
         const amountInput: HTMLInputElement = getAmountInput()
         assertEmptyInput(amountInput)
-        await submitIncomeTransaction(VALID_NAME, amount)
-        await submitIncomeTransaction(VALID_NAME, amount)
+        await submitIncomeTransaction(user, VALID_NAME, amount)
+        await submitIncomeTransaction(user, VALID_NAME, amount)
         expect(getIncomeTotalElement()).toHaveTextContent("$6.40")
       })
 
@@ -442,7 +307,7 @@ describe("transactions", () => {
         const amount: string = "3.20"
         const amountInput: HTMLInputElement = getAmountInput()
         assertEmptyInput(amountInput)
-        await submitIncomeTransaction(VALID_NAME, amount)
+        await submitIncomeTransaction(user, VALID_NAME, amount)
         const incomeTotalElement = getIncomeTotalElement()
         expect(incomeTotalElement).toHaveTextContent("$3.20")
         await user.click(getFirstTransactionDeleteButton())
@@ -464,14 +329,14 @@ describe("transactions", () => {
       test("should be negative", async () => {
         render(<Wallet />)
         const cashFlow: HTMLElement = getCashFlowElement()
-        await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+        await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
         expect(cashFlow).toHaveTextContent("-$" + VALID_AMOUNT)
       })
 
       test("should be positive", async () => {
         render(<Wallet />)
         const cashFlow: HTMLElement = getCashFlowElement()
-        await submitIncomeTransaction(VALID_NAME, VALID_AMOUNT)
+        await submitIncomeTransaction(user, VALID_NAME, VALID_AMOUNT)
         expect(cashFlow).toHaveTextContent("$" + VALID_AMOUNT)
       })
     })
@@ -510,7 +375,7 @@ describe("transactions", () => {
 
         await user.click(firstOfCurrentMonth)
         expect(walletTransactionDate).toHaveTextContent(getDisplayedTransactionDateFormat(firstOfMonth))
-        await submitExpenseTransaction(VALID_NAME, VALID_AMOUNT)
+        await submitExpenseTransaction(user, VALID_NAME, VALID_AMOUNT)
 
         await user.click(secondOfCurrentMonth)
         expect(walletTransactionDate).toHaveTextContent(getDisplayedTransactionDateFormat(secondOfMonth))

--- a/components/wallet/transactionHistory.tsx
+++ b/components/wallet/transactionHistory.tsx
@@ -1,21 +1,53 @@
-import React, { FC, useContext } from "react"
+import React, { FC, useContext, useState } from "react"
 import TransactionInfo from "./transactionInfo"
 import styles from "../../styles/components/wallet/TransactionHistory.module.css"
 import { Transaction, TransactionContext } from "../../pages/wallet"
 
 const TransactionHistory:FC<any> = () => {
+  const [pageIndex, setPageIndex] = useState(1)
   const transactions: Array<Transaction> = useContext(TransactionContext)
+
+  function getPaginatedTransactions(transactions: Array<Transaction>) {
+    const transactionsPerPage: number = 10
+    const start = (pageIndex - 1) * transactionsPerPage
+    const end = pageIndex * transactionsPerPage
+    return (
+      <div aria-label="transactions-container">
+        {
+          transactions.slice(start, end).map((transaction: Transaction) => {
+            return (
+              <TransactionInfo key={transaction.id}
+                transaction={transaction}
+              />
+            )
+          })
+        }
+      </div>
+    )
+  }
 
   return (
     <div aria-label="wallet-transaction-history" className={styles.container}>
+      <div className={styles.pagination}>
+        <button aria-label="previous-transaction-history"
+                disabled={pageIndex === 1}
+                onClick={() => setPageIndex(pageIndex - 1)}
+        >
+          Previous
+        </button>
+        <button aria-label="current-transaction-history-page">
+          {pageIndex}
+        </button>
+        <button aria-label="next-transaction-history"
+                disabled={(pageIndex * 10) >= transactions.length}
+                onClick={() => setPageIndex(pageIndex + 1)}
+        >
+          Next
+        </button>
+      </div>
+
       { transactions &&
-        transactions.map((transaction: Transaction) => {
-          return (
-            <TransactionInfo key={transaction.id}
-                             transaction={transaction}
-            />
-          )
-        })
+        getPaginatedTransactions(transactions)
       }
     </div>
   )

--- a/components/wallet/transactionInfo.tsx
+++ b/components/wallet/transactionInfo.tsx
@@ -16,7 +16,9 @@ const TransactionInfo:FC<TransactionInfoProps> = (props) => {
     : styles.income
 
   return (
-    <div className={`${styles.container} ${transactionTypeStyle}`}>
+    <div className={`${styles.container} ${transactionTypeStyle}`}
+         aria-label="transaction"
+    >
       <h1 className={styles.name}>{props.transaction.name}</h1>
       <div className={styles.info}>
         <h2>{props.transaction.amount.format()}</h2>

--- a/styles/components/wallet/TransactionHistory.module.css
+++ b/styles/components/wallet/TransactionHistory.module.css
@@ -4,3 +4,14 @@
   justify-content: flex-start;
   width: 100%;
 }
+
+.pagination {
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 1em;
+  gap: 1em;
+}
+
+.pagination button {
+  padding: 0.4em 1em;
+}


### PR DESCRIPTION
Add previous, next button for pagination
Add current page number
![image](https://user-images.githubusercontent.com/38811217/209459060-be9da070-66c7-4095-8f63-38e9e3088531.png)

Refactor tests into different files
