### PR TITLE
Add currency symbol retrieval using Incremental Static Regeneration (ISR)

### DIFF
--- a/__tests__/pages/exchange/exchange.test.tsx
+++ b/__tests__/pages/exchange/exchange.test.tsx
@@ -1,13 +1,23 @@
-import axios from "axios"
+import axios, { AxiosResponse } from "axios"
 import Swal from "sweetalert2"
-import { test, expect, describe, vi, afterEach } from "vitest"
+import { test, expect, describe, vi, beforeAll, afterEach } from "vitest"
 import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { UserEvent } from "@testing-library/user-event/setup/setup"
+
 import Exchange from "../../../pages/exchange"
 import { mockExchangeRate } from "../../serverSetup"
+import { CurrencySymbolApiResponse, Symbol } from "../../../lib/exchange/currency/symbols"
 
 describe("exchange rate", () => {
+  let symbols: Record<string, Symbol>
+
+  beforeAll(async () => {
+    const response: AxiosResponse = await axios.get("/api/exchange/currency/symbols")
+    const data: CurrencySymbolApiResponse = response.data
+    symbols = data.symbols
+  })
+
   const user: UserEvent = userEvent.setup()
 
   function getConversionAmountInput(): HTMLInputElement {
@@ -32,7 +42,7 @@ describe("exchange rate", () => {
   }
 
   test("should show amount to convert input element", () => {
-    render(<Exchange />)
+    render(<Exchange symbols={symbols} />)
     const conversionAmountInput: HTMLInputElement = getConversionAmountInput()
     expect(conversionAmountInput.getAttribute("type")).toEqual("number")
     expect(conversionAmountInput.getAttribute("min")).toEqual("0.01")
@@ -41,7 +51,7 @@ describe("exchange rate", () => {
 
   describe("from currency", () => {
     test("should show 'from' currency dropdown", () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       const fromCurrencyDropdown: HTMLSelectElement = getFromCurrencyDropdown()
       expect(fromCurrencyDropdown).toBeInTheDocument()
       expect(fromCurrencyDropdown).toHaveAttribute("required")
@@ -52,7 +62,7 @@ describe("exchange rate", () => {
     })
 
     test("should allow user to select 'from' currency", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       const fromCurrencyDropdown: HTMLSelectElement = getFromCurrencyDropdown()
       const fromSgdOption: HTMLOptionElement = getOption(fromCurrencyDropdown, "from-SGD")
       expect(fromSgdOption.selected).toBeFalsy()
@@ -63,7 +73,7 @@ describe("exchange rate", () => {
 
   describe("to currency", () => {
     test("should show 'to' currency dropdown", () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       const toCurrencyDropdown: HTMLSelectElement = getToCurrencyDropdown()
       expect(toCurrencyDropdown).toBeInTheDocument()
       expect(toCurrencyDropdown).toHaveAttribute("required")
@@ -74,7 +84,7 @@ describe("exchange rate", () => {
     })
 
     test("should allow user to select 'to' currency", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       const toCurrencyDropdown: HTMLSelectElement = getToCurrencyDropdown()
       const toSgdOption: HTMLOptionElement = getOption(toCurrencyDropdown, "to-SGD")
       expect(toSgdOption.selected).toBeFalsy()
@@ -103,7 +113,7 @@ describe("exchange rate", () => {
     }
 
     test("should submit valid exchange request", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       await submitCurrencyConvert("0.01", "SGD", "USD")
       expect(axiosSpy).toHaveBeenCalledOnce()
       expect(axiosSpy).toHaveBeenCalledWith("/api/exchange", {
@@ -114,13 +124,13 @@ describe("exchange rate", () => {
     })
 
     test("should not submit exchange request for invalid zero amount", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       await submitCurrencyConvert("0", "SGD", "USD")
       expect(axiosSpy).not.toHaveBeenCalled()
     })
 
     test("should not submit exchange request for negative amount", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       await expect(
         submitCurrencyConvert("-2", "SGD", "SGD"),
       ).resolves.not.toThrowError()
@@ -128,14 +138,14 @@ describe("exchange rate", () => {
     })
 
     test("should not submit exchange request for same currency conversion", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       await submitCurrencyConvert("10", "SGD", "SGD")
       expect(axiosSpy).not.toHaveBeenCalled()
       expect(alertSpy).toHaveBeenCalledTimes(1)
     })
 
     test("should display exchange result", async () => {
-      render(<Exchange />)
+      render(<Exchange symbols={symbols} />)
       await submitCurrencyConvert("2", "SGD", "USD")
       const currencyExchangeResult: HTMLElement = getCurrencyExchangeResult()
       const expectedExchangeAmount: string = (mockExchangeRate * 2).toFixed(3)

--- a/__tests__/pages/exchange/exchange.test.tsx
+++ b/__tests__/pages/exchange/exchange.test.tsx
@@ -5,7 +5,7 @@ import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { UserEvent } from "@testing-library/user-event/setup/setup"
 import Exchange from "../../../pages/exchange"
-import { mockExchangeRate } from "../../setup"
+import { mockExchangeRate } from "../../serverSetup"
 
 describe("exchange rate", () => {
   const user: UserEvent = userEvent.setup()

--- a/__tests__/serverSetup.ts
+++ b/__tests__/serverSetup.ts
@@ -1,0 +1,104 @@
+import { rest } from "msw"
+import { Data as CreateTransactionResponseData } from "../pages/api/wallet/transaction/create"
+import {
+  CurrencyConvertResponse as ExchangeResponseData,
+  RequestData as ExchangeRequestData
+} from "../pages/api/exchange"
+import { CurrencySymbolResponse } from "../pages/api/exchange/currency/symbols"
+import { setupServer } from "msw/node"
+import { nanoid } from "nanoid"
+
+export const mockExchangeRate: number = 1.352
+
+export const restHandlers = [
+  rest.post("/api/wallet/transaction/create", async (req, res, ctx) => {
+    const requestData: CreateTransactionResponseData = await req.json()
+    const transaction = getTransaction(requestData)
+    return res(ctx.status(200), ctx.json(transaction))
+  }),
+  rest.get("/api/exchange", async (req, res, ctx) => {
+    // https://api.exchangerate.host/convert
+    const requestData: ExchangeRequestData = await req.json()
+    const mockResponse: ExchangeResponseData = {
+      date: new Date("2022-12-26"),
+      rate: mockExchangeRate,
+      result: getExchangeResult(requestData.amount),
+    }
+    return res(ctx.status(200), ctx.json(mockResponse))
+  }),
+  rest.post("/api/exchange", async (req, res, ctx) => {
+    // https://api.exchangerate.host/convert
+    const requestData: ExchangeRequestData = await req.json()
+    const mockResponse: ExchangeResponseData = {
+      date: new Date("2022-12-30"),
+      rate: mockExchangeRate,
+      result: getExchangeResult(requestData.amount),
+    }
+    return res(ctx.status(200), ctx.json(mockResponse))
+  }),
+  rest.get("/api/exchange/currency/symbols", async (req, res, ctx) => {
+    // https://api.exchangerate.host/symbols
+    const mockResponse: CurrencySymbolResponse = {
+      "symbols": {
+        "BTC": {
+          "description": "Bitcoin",
+          "code": "BTC"
+        },
+        "CNH": {
+          "description": "Chinese Yuan (Offshore)",
+          "code": "CNH"
+        },
+        "CNY": {
+          "description": "Chinese Yuan",
+          "code": "CNY"
+        },
+        "EUR": {
+          "description": "Euro",
+          "code": "EUR"
+        },
+        "GBP": {
+          "description": "British Pound Sterling",
+          "code": "GBP"
+        },
+        "HKD": {
+          "description": "Hong Kong Dollar",
+          "code": "HKD"
+        },
+        "JPY": {
+          "description": "Japanese Yen",
+          "code": "JPY"
+        },
+        "SGD": {
+          "description": "Singapore Dollar",
+          "code": "SGD"
+        },
+        "TWD": {
+          "description": "New Taiwan Dollar",
+          "code": "TWD"
+        },
+        "USD": {
+          "description": "United States Dollar",
+          "code": "USD"
+        },
+      }
+    }
+    return res(ctx.status(200), ctx.json(mockResponse))
+  })
+]
+
+export const server = setupServer(...restHandlers)
+
+function getTransaction(data: CreateTransactionResponseData) {
+  const { name, amount, isExpense, transactionDate }: CreateTransactionResponseData = data
+  return {
+    id: nanoid(),
+    name,
+    amount,
+    isExpense,
+    transactionDate
+  }
+}
+
+function getExchangeResult(amount: number) {
+  return Number((amount * mockExchangeRate).toFixed(3));
+}

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -5,24 +5,25 @@ import { rest } from "msw"
 import { setupServer } from "msw/node"
 import { nanoid } from "nanoid"
 import { enableAllPlugins } from "immer"
-import { Data as createTransactionResponseData } from "../pages/api/wallet/transaction/create"
+import { Data as CreateTransactionResponseData } from "../pages/api/wallet/transaction/create"
 import {
-  CurrencyConvertResponse as exchangeResponseData,
-  RequestData as exchangeRequestData
+  CurrencyConvertResponse as ExchangeResponseData,
+  RequestData as ExchangeRequestData
 } from "../pages/api/exchange/index"
+import { CurrencySymbolResponse } from "../pages/api/exchange/currency/symbols"
 
 export const mockExchangeRate: number = 1.352
 
 export const restHandlers = [
   rest.post("/api/wallet/transaction/create", async (req, res, ctx) => {
-    const requestData: createTransactionResponseData = await req.json()
+    const requestData: CreateTransactionResponseData = await req.json()
     const transaction = getTransaction(requestData)
     return res(ctx.status(200), ctx.json(transaction))
   }),
   rest.get("/api/exchange", async (req, res, ctx) => {
     // https://api.exchangerate.host/convert
-    const requestData: exchangeRequestData = await req.json()
-    const mockResponse: exchangeResponseData = {
+    const requestData: ExchangeRequestData = await req.json()
+    const mockResponse: ExchangeResponseData = {
       date: new Date("2022-12-26"),
       rate: mockExchangeRate,
       result: getExchangeResult(requestData.amount),
@@ -31,11 +32,59 @@ export const restHandlers = [
   }),
   rest.post("/api/exchange", async (req, res, ctx) => {
     // https://api.exchangerate.host/convert
-    const requestData: exchangeRequestData = await req.json()
-    const mockResponse: exchangeResponseData = {
+    const requestData: ExchangeRequestData = await req.json()
+    const mockResponse: ExchangeResponseData = {
       date: new Date("2022-12-30"),
       rate: mockExchangeRate,
       result: getExchangeResult(requestData.amount),
+    }
+    return res(ctx.status(200), ctx.json(mockResponse))
+  }),
+  rest.get("/api/exchange/currency/symbols", async (req, res, ctx) => {
+    // https://api.exchangerate.host/symbols
+    const mockResponse: CurrencySymbolResponse = {
+      "symbols": {
+        "BTC": {
+          "description": "Bitcoin",
+          "code": "BTC"
+        },
+        "CNH": {
+          "description": "Chinese Yuan (Offshore)",
+          "code": "CNH"
+        },
+        "CNY": {
+          "description": "Chinese Yuan",
+          "code": "CNY"
+        },
+        "EUR": {
+          "description": "Euro",
+          "code": "EUR"
+        },
+        "GBP": {
+          "description": "British Pound Sterling",
+          "code": "GBP"
+        },
+        "HKD": {
+          "description": "Hong Kong Dollar",
+          "code": "HKD"
+        },
+        "JPY": {
+          "description": "Japanese Yen",
+          "code": "JPY"
+        },
+        "SGD": {
+          "description": "Singapore Dollar",
+          "code": "SGD"
+        },
+        "TWD": {
+          "description": "New Taiwan Dollar",
+          "code": "TWD"
+        },
+        "USD": {
+          "description": "United States Dollar",
+          "code": "USD"
+        },
+      }
     }
     return res(ctx.status(200), ctx.json(mockResponse))
   })
@@ -84,8 +133,8 @@ function mockNextFont() {
   })
 }
 
-function getTransaction(data: createTransactionResponseData) {
-  const { name, amount, isExpense, transactionDate }: createTransactionResponseData = data
+function getTransaction(data: CreateTransactionResponseData) {
+  const { name, amount, isExpense, transactionDate }: CreateTransactionResponseData = data
   return {
     id: nanoid(),
     name,

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,96 +1,8 @@
-import { expect, beforeAll, afterEach, afterAll, vi } from "vitest"
+import { afterAll, afterEach, beforeAll, expect, vi } from "vitest"
 import { cleanup } from "@testing-library/react"
 import matchers from "@testing-library/jest-dom/matchers"
-import { rest } from "msw"
-import { setupServer } from "msw/node"
-import { nanoid } from "nanoid"
 import { enableAllPlugins } from "immer"
-import { Data as CreateTransactionResponseData } from "../pages/api/wallet/transaction/create"
-import {
-  CurrencyConvertResponse as ExchangeResponseData,
-  RequestData as ExchangeRequestData
-} from "../pages/api/exchange/index"
-import { CurrencySymbolResponse } from "../pages/api/exchange/currency/symbols"
-
-export const mockExchangeRate: number = 1.352
-
-export const restHandlers = [
-  rest.post("/api/wallet/transaction/create", async (req, res, ctx) => {
-    const requestData: CreateTransactionResponseData = await req.json()
-    const transaction = getTransaction(requestData)
-    return res(ctx.status(200), ctx.json(transaction))
-  }),
-  rest.get("/api/exchange", async (req, res, ctx) => {
-    // https://api.exchangerate.host/convert
-    const requestData: ExchangeRequestData = await req.json()
-    const mockResponse: ExchangeResponseData = {
-      date: new Date("2022-12-26"),
-      rate: mockExchangeRate,
-      result: getExchangeResult(requestData.amount),
-    }
-    return res(ctx.status(200), ctx.json(mockResponse))
-  }),
-  rest.post("/api/exchange", async (req, res, ctx) => {
-    // https://api.exchangerate.host/convert
-    const requestData: ExchangeRequestData = await req.json()
-    const mockResponse: ExchangeResponseData = {
-      date: new Date("2022-12-30"),
-      rate: mockExchangeRate,
-      result: getExchangeResult(requestData.amount),
-    }
-    return res(ctx.status(200), ctx.json(mockResponse))
-  }),
-  rest.get("/api/exchange/currency/symbols", async (req, res, ctx) => {
-    // https://api.exchangerate.host/symbols
-    const mockResponse: CurrencySymbolResponse = {
-      "symbols": {
-        "BTC": {
-          "description": "Bitcoin",
-          "code": "BTC"
-        },
-        "CNH": {
-          "description": "Chinese Yuan (Offshore)",
-          "code": "CNH"
-        },
-        "CNY": {
-          "description": "Chinese Yuan",
-          "code": "CNY"
-        },
-        "EUR": {
-          "description": "Euro",
-          "code": "EUR"
-        },
-        "GBP": {
-          "description": "British Pound Sterling",
-          "code": "GBP"
-        },
-        "HKD": {
-          "description": "Hong Kong Dollar",
-          "code": "HKD"
-        },
-        "JPY": {
-          "description": "Japanese Yen",
-          "code": "JPY"
-        },
-        "SGD": {
-          "description": "Singapore Dollar",
-          "code": "SGD"
-        },
-        "TWD": {
-          "description": "New Taiwan Dollar",
-          "code": "TWD"
-        },
-        "USD": {
-          "description": "United States Dollar",
-          "code": "USD"
-        },
-      }
-    }
-    return res(ctx.status(200), ctx.json(mockResponse))
-  })
-]
-
-const server = setupServer(...restHandlers)
+import { server } from "./serverSetup"
 
 // extends Vitest's expect method with methods from react-testing-library
 expect.extend(matchers)
@@ -131,19 +43,4 @@ function mockNextFont() {
       })
     }
   })
-}
-
-function getTransaction(data: CreateTransactionResponseData) {
-  const { name, amount, isExpense, transactionDate }: CreateTransactionResponseData = data
-  return {
-    id: nanoid(),
-    name,
-    amount,
-    isExpense,
-    transactionDate
-  }
-}
-
-function getExchangeResult(amount: number) {
-  return Number((amount * mockExchangeRate).toFixed(3));
 }

--- a/components/exchange/currencyConvertForm.tsx
+++ b/components/exchange/currencyConvertForm.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from "react"
 import Swal from "sweetalert2"
 import Currency from "../currency"
+import { Symbol } from "../../lib/exchange/currency/symbols"
 import styles from "../../styles/components/exchange/CurrencyConvertForm.module.css"
 
 const ErrorToast = Swal.mixin({
@@ -14,7 +15,8 @@ const ErrorToast = Swal.mixin({
 })
 
 interface CurrencyConvertFormProps {
-  handleSubmit:  (fromCurrency: string, toCurrency: string, amount: Currency) => void
+  handleSubmit:  (fromCurrency: string, toCurrency: string, amount: Currency) => void,
+  symbols: Record<string, Symbol>,
 }
 
 const CurrencyConvertForm:FC<CurrencyConvertFormProps> = (props) => {
@@ -44,6 +46,19 @@ const CurrencyConvertForm:FC<CurrencyConvertFormProps> = (props) => {
 
   function handleChangeAmount(event: React.ChangeEvent<HTMLInputElement>): void {
     setAmount(event.target.value)
+  }
+
+  function getCurrencyInputOptions(prepend: string): JSX.Element[] {
+    return Object.entries(props.symbols).map(([currencyCode, symbol]) => {
+      const label: string = `${prepend}-${currencyCode}`
+      return (
+        <option value={currencyCode}
+                key={label}
+                aria-label={label}>
+          {`${currencyCode} - ${symbol.description}`}
+        </option>
+      )
+    })
   }
 
   return (
@@ -78,8 +93,7 @@ const CurrencyConvertForm:FC<CurrencyConvertFormProps> = (props) => {
             <option value="" aria-label="default-from-currency" disabled hidden>
               -- select an option --
             </option>
-            <option value="SGD" aria-label="from-SGD">SGD - Singapore Dollar</option>
-            <option value="USD" aria-label="from-USD">USD - United States Dollar</option>
+            { props.symbols && getCurrencyInputOptions("from") }
           </select>
         </div>
         <div className={styles.currencyFormInput}>
@@ -93,8 +107,7 @@ const CurrencyConvertForm:FC<CurrencyConvertFormProps> = (props) => {
             <option value="" aria-label="default-to-currency" disabled hidden>
               -- select an option --
             </option>
-            <option value="SGD" aria-label="to-SGD">SGD - Singapore Dollar</option>
-            <option value="USD" aria-label="to-USD">USD - United States Dollar</option>
+            { props.symbols && getCurrencyInputOptions("to") }
           </select>
         </div>
         <button type="submit" className={styles.currencyFormButton}>

--- a/lib/exchange/currency/symbols.ts
+++ b/lib/exchange/currency/symbols.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosResponse } from "axios"
+
+export type Symbol = {
+  description: string,
+  code: string,
+}
+
+export type CurrencySymbolApiResponse = {
+  motd: {
+    url: string,
+  },
+  success: boolean,
+  symbols: Record<string, Symbol>,
+}
+
+export async function getCurrencySymbols() {
+  const url: string = "https://api.exchangerate.host/symbols"
+  const response: AxiosResponse = await axios.get(url)
+  if (response.status !== 200) {
+    throw new Error("External Currency API is down")
+  }
+  const { symbols }: CurrencySymbolApiResponse = response.data
+  return { symbols }
+}

--- a/pages/api/exchange/currency/symbols.ts
+++ b/pages/api/exchange/currency/symbols.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import axios, { AxiosResponse } from "axios"
+
+export type CurrencySymbolResponse = {
+  symbols?: Record<string, Symbol>,
+  error?: string,
+}
+
+type CurrencySymbolApiResponse = {
+  motd: {
+    url: string,
+  },
+  success: boolean,
+  symbols: Record<string, Symbol>,
+}
+
+export type Symbol = {
+  description: string,
+  code: string,
+}
+
+const allowedMethods = ["GET"]
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CurrencySymbolResponse>
+) {
+  if (!allowedMethods.includes(String(req.method)) || req.method == "OPTIONS") {
+    return res.status(405)
+      .send({ error: "Method not allowed" })
+  }
+  if (req.method === "GET") {
+    const url: string = "https://api.exchangerate.host/symbols"
+    const response: AxiosResponse = await axios.get(url)
+    if (response.status !== 200) {
+      // TODO handle error, retry with exponential backoff algorithm
+      return res.status(503)
+        .send({ error: "External Currency API is down" })
+    }
+    const { symbols }: CurrencySymbolApiResponse = response.data
+    return res.status(200).json({ symbols })
+  }
+}

--- a/pages/api/exchange/currency/symbols.ts
+++ b/pages/api/exchange/currency/symbols.ts
@@ -1,22 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next"
-import axios, { AxiosResponse } from "axios"
+import { getCurrencySymbols, Symbol } from "../../../../lib/exchange/currency/symbols"
 
 export type CurrencySymbolResponse = {
   symbols?: Record<string, Symbol>,
   error?: string,
-}
-
-type CurrencySymbolApiResponse = {
-  motd: {
-    url: string,
-  },
-  success: boolean,
-  symbols: Record<string, Symbol>,
-}
-
-export type Symbol = {
-  description: string,
-  code: string,
 }
 
 const allowedMethods = ["GET"]
@@ -30,14 +17,13 @@ export default async function handler(
       .send({ error: "Method not allowed" })
   }
   if (req.method === "GET") {
-    const url: string = "https://api.exchangerate.host/symbols"
-    const response: AxiosResponse = await axios.get(url)
-    if (response.status !== 200) {
-      // TODO handle error, retry with exponential backoff algorithm
+    try {
+      const { symbols } = await getCurrencySymbols()
+      return res.status(200)
+        .json({ symbols })
+    } catch (error) {
       return res.status(503)
         .send({ error: "External Currency API is down" })
     }
-    const { symbols }: CurrencySymbolApiResponse = response.data
-    return res.status(200).json({ symbols })
   }
 }


### PR DESCRIPTION
- Extract test server setup to own file (setupServer.ts)
- Add error toast when currency exchange data is not available (`null` "result" and "rate" attribute returned from currency API)
- Mock endpoint for test (currency symbol retrieval)
- Extract api retrieval to common lib/ folder. To prevent 2 api calls (frontend -> nextjs api route -> actual api). 
https://nextjs.org/docs/basic-features/data-fetching/get-static-props#write-server-side-code-directly

ISR - https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration